### PR TITLE
Add request logging middleware

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,14 +2,25 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 import logging
+from logging.handlers import RotatingFileHandler
 
 from app.api.api import api_router
 from app.core.config import settings
 from app.db.database import engine, Base
+from app.middleware.logging_middleware import RequestLoggingMiddleware
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+# Configure logging with rotating file handler for better persistence
+log_handlers = [
+    logging.StreamHandler(),
+    RotatingFileHandler("api.log", maxBytes=1_000_000, backupCount=3),
+]
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=log_handlers,
+)
 logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -21,11 +32,12 @@ async def lifespan(app: FastAPI):
     # Shutdown
     logger.info("Shutting down application...")
 
+
 app = FastAPI(
     title=settings.PROJECT_NAME,
     version=settings.VERSION,
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 # Set up CORS
@@ -37,8 +49,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Log each request with response status and timing
+app.add_middleware(RequestLoggingMiddleware)
+
 # Include API router
 app.include_router(api_router, prefix=settings.API_V1_STR)
+
 
 @app.get("/health")
 async def health_check():

--- a/backend/app/middleware/logging_middleware.py
+++ b/backend/app/middleware/logging_middleware.py
@@ -1,0 +1,26 @@
+import logging
+import time
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        start_time = time.time()
+        logger.info(
+            f"--> {request.method} {request.url.path} from {request.client.host}"
+        )
+        try:
+            response = await call_next(request)
+            status = response.status_code
+            return response
+        except Exception as e:
+            logger.error(f"Request error: {request.method} {request.url.path}: {e}")
+            raise
+        finally:
+            duration = time.time() - start_time
+            logger.info(
+                f"<-- {request.method} {request.url.path} status={locals().get('status', 'error')} time={duration:.2f}s"
+            )


### PR DESCRIPTION
## Summary
- add request logging middleware for API
- persist API logs via rotating file handler

## Testing
- `black backend/app/middleware/logging_middleware.py backend/app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e0324bd6c832e879e4b63db4b18a6