### PR TITLE
Fix log string line length

### DIFF
--- a/backend/app/middleware/logging_middleware.py
+++ b/backend/app/middleware/logging_middleware.py
@@ -10,17 +10,22 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         start_time = time.time()
         logger.info(
-            f"--> {request.method} {request.url.path} from {request.client.host}"
+            f"--> {request.method} {request.url.path} "
+            f"from {request.client.host}"
         )
         try:
             response = await call_next(request)
             status = response.status_code
             return response
         except Exception as e:
-            logger.error(f"Request error: {request.method} {request.url.path}: {e}")
+            logger.error(
+                f"Request error: {request.method} {request.url.path}: {e}"
+            )
             raise
         finally:
             duration = time.time() - start_time
             logger.info(
-                f"<-- {request.method} {request.url.path} status={locals().get('status', 'error')} time={duration:.2f}s"
+                f"<-- {request.method} {request.url.path} "
+                f"status={locals().get('status', 'error')} "
+                f"time={duration:.2f}s"
             )


### PR DESCRIPTION
## Summary
- shorten long f-strings in `logging_middleware` to satisfy flake8 E501

## Testing
- `flake8 app/middleware/logging_middleware.py`
- `black app/middleware/logging_middleware.py --line-length 79`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc1a3f814832eb3a0c523291e4500