### PR TITLE
Fix Redis defaults and start worker in dev script

### DIFF
--- a/README_COMPREHENSIVE.md
+++ b/README_COMPREHENSIVE.md
@@ -108,7 +108,7 @@ OPENAI_API_KEY=sk-your-openai-api-key-here
 DATABASE_URL=postgresql://docuser:docpass@postgres:5432/docprocessor
 
 # Redis Queue (auto-configured)
-REDIS_URL=redis://redis:6379/0
+REDIS_URL=redis://localhost:6379/0
 
 # Optional - AWS S3 Storage
 AWS_ACCESS_KEY_ID=your-access-key

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -67,8 +67,15 @@ echo "Starting backend server on port $BACKEND_PORT..."
 python start.py &
 BACKEND_PID=$!
 
+# Step 6b: Start worker process
+cd ../worker
+echo "Starting background worker..."
+python worker.py &
+WORKER_PID=$!
+cd ..
+
 # Step 7: Install frontend dependencies
-cd ../frontend
+cd frontend
 
 if [ ! -d "node_modules" ]; then
     echo ""
@@ -116,6 +123,7 @@ cleanup() {
     echo "Shutting down services..."
     kill $BACKEND_PID 2>/dev/null
     kill $FRONTEND_PID 2>/dev/null
+    kill $WORKER_PID 2>/dev/null
     echo "Services stopped."
     exit 0
 }

--- a/worker/.env
+++ b/worker/.env
@@ -1,5 +1,5 @@
 # Redis configuration
-REDIS_URL=redis://redis:6379/0
+REDIS_URL=redis://localhost:6379/0
 
 # Database configuration
 DATABASE_URL=postgresql://docuser:docpass@postgres:5432/docprocessor


### PR DESCRIPTION
## Summary
- run worker automatically in `scripts/dev.sh`
- use `localhost` Redis defaults in worker
- update worker `.env` and comprehensive README

## Testing
- `black worker/worker.py`
- `flake8 worker/worker.py` *(fails: many style errors)*
- `npm run lint` in `frontend`
- `npm run format` *(fails: missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841d62aff80832e96663a30726d81e6