### PR TITLE
docs: clarify data storage for Excel export

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
 - **Charts & analytics** included
 - **Batch export** multiple docs
 - **Metadata sheets** with insights
+- **Results stored** in PostgreSQL for re-export
+- **Columns** mapped from stored JSON keys
 
 </td>
 <td width="33%" valign="top">

--- a/README_COMPREHENSIVE.md
+++ b/README_COMPREHENSIVE.md
@@ -62,6 +62,8 @@ The AI Document Processor is a modern web application that automatically extract
 - **Batch export** for processing multiple documents
 - **Template Mode** - Consolidate all documents into columns/rows format
 - **Custom templates** for different document types
+- **Results stored** in PostgreSQL for re-export
+- **Columns mapped** from stored JSON keys
 
 ### 🎨 Modern Interface
 - **Dark/Light themes** with system preference detection


### PR DESCRIPTION
## Summary
- document that extracted data is saved in PostgreSQL
- mention spreadsheet columns come from stored JSON keys

## Testing
- `flake8 app/` *(fails: E501 line too long, F401 imported but unused, etc.)*
- `npm run lint`
- `npm run format` *(fails: Missing script)*
- `pytest`
- `node test/verify-app.js` *(fails: Could not find Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684860379cf8832e8c27b1b44c7ecd91