### PR TITLE
Improve processing progress reporting

### DIFF
--- a/backend/app/utils/background_tasks.py
+++ b/backend/app/utils/background_tasks.py
@@ -19,36 +19,46 @@ logger = logging.getLogger(__name__)
 redis_conn = Redis.from_url(settings.REDIS_URL)
 queue = Queue(connection=redis_conn)
 
+
 def process_document_task(document_id: int, schema: Optional[Dict[str, Any]] = None):
     """Background task to process a document"""
     db: Session = SessionLocal()
     start_time = time.time()
-    
+
     try:
         # Get document
         document = db.query(Document).filter(Document.id == document_id).first()
         if not document:
             logger.error(f"Document {document_id} not found")
             return
-        
+
         # Update status
         document.status = ProcessingStatus.PROCESSING
         document.progress = 0.1
         db.commit()
-        
+
         # Get file path
         file_path = f"{settings.UPLOAD_DIR}/{document.filename}"
-        
+
         # Process document
         processor = DocumentProcessor()
-        
+
         # Convert async function to sync for RQ
         import asyncio
+
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
-            result = loop.run_until_complete(processor.process_pdf(file_path, schema))
-            
+
+            def progress_cb(value: float):
+                document.progress = value
+                db.add(document)
+                db.commit()
+
+            result = loop.run_until_complete(
+                processor.process_pdf(file_path, schema, progress_callback=progress_cb)
+            )
+
             if result["success"]:
                 # Update document with results
                 document.status = ProcessingStatus.COMPLETED
@@ -63,50 +73,59 @@ def process_document_task(document_id: int, schema: Optional[Dict[str, Any]] = N
                 document.status = ProcessingStatus.FAILED
                 document.error_message = result.get("error", "Unknown error occurred")
                 document.progress = 0.0
-                
+
         except Exception as e:
-            logger.error(f"Error processing document {document_id}: {str(e)}", exc_info=True)
+            logger.error(
+                f"Error processing document {document_id}: {str(e)}", exc_info=True
+            )
             document.status = ProcessingStatus.FAILED
             document.error_message = str(e)
             document.progress = 0.0
-            
+
         finally:
             loop.close()
-            
+
     except Exception as e:
-        logger.error(f"Error in background task for document {document_id}: {str(e)}", exc_info=True)
-        if 'document' in locals():
+        logger.error(
+            f"Error in background task for document {document_id}: {str(e)}",
+            exc_info=True,
+        )
+        if "document" in locals():
             document.status = ProcessingStatus.FAILED
             document.error_message = f"Processing error: {str(e)}"
-        
+
     finally:
-        if 'document' in locals():
+        if "document" in locals():
             db.add(document)
             db.commit()
         db.close()
 
-def enqueue_document_processing(document_id: int, schema: Optional[Dict[str, Any]] = None) -> str:
+
+def enqueue_document_processing(
+    document_id: int, schema: Optional[Dict[str, Any]] = None
+) -> str:
     """Enqueue a document for processing and return the job ID"""
     job = queue.enqueue(
-        'app.utils.background_tasks.process_document_task',
+        "app.utils.background_tasks.process_document_task",
         document_id,
         schema,
-        job_timeout=3600  # 1 hour timeout
+        job_timeout=3600,  # 1 hour timeout
     )
     return job.id
+
 
 def get_job_status(job_id: str) -> Dict[str, Any]:
     """Get the status of a background job"""
     try:
         job = Job.fetch(job_id, connection=redis_conn)
         return {
-            'id': job.id,
-            'status': job.get_status(),
-            'result': job.result,
-            'error': job.exc_info,
-            'created_at': job.created_at,
-            'started_at': job.started_at,
-            'ended_at': job.ended_at
+            "id": job.id,
+            "status": job.get_status(),
+            "result": job.result,
+            "error": job.exc_info,
+            "created_at": job.created_at,
+            "started_at": job.started_at,
+            "ended_at": job.ended_at,
         }
     except Exception as e:
-        return {'error': str(e), 'status': 'failed'}
+        return {"error": str(e), "status": "failed"}


### PR DESCRIPTION
## Summary
- add optional progress callback to `DocumentProcessor.process_pdf`
- update background task to report progress to the database during processing

## Testing
- `flake8 backend/app/utils/background_tasks.py backend/app/services/document_processor.py | head -n 20`
- `black backend/app/services/document_processor.py backend/app/utils/background_tasks.py`
- `npm run lint` *(fails: `next` not found)*
- `npm run format` *(fails: missing script)*
- `node test/verify-app.js` *(fails: Chrome not found)*
- `pytest -q test/test-openai.py` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_684861a24958832e8dd57f16320855de