### PR TITLE
Fix lint and format issues

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,6 @@
 from typing import List, Union
 from pydantic_settings import BaseSettings
-from pydantic import AnyHttpUrl, validator
+from pydantic import AnyHttpUrl
 import os
 
 
@@ -33,7 +33,10 @@ class Settings(BaseSettings):
     # Database
     DATABASE_URL: str = os.getenv(
         "DATABASE_URL",
-        f"postgresql://docuser:docpass@localhost:{os.getenv('POSTGRES_PORT', '5432')}/docprocessor",
+        (
+            "postgresql://docuser:docpass@localhost:"
+            f"{os.getenv('POSTGRES_PORT', '5432')}/docprocessor"
+        ),
     )
 
     # Redis

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
@@ -36,6 +37,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.1.8",
     "postcss": "^8",
+    "prettier": "^3.5.3",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary
- clean up unused import and long line in config
- add prettier config and format script to frontend
- ensure dev dependencies include prettier

## Testing
- `flake8 app/core/config.py app/services/s3_service.py`
- `npm run lint`
- `npm run format`
- `pytest`
- `node test/verify-app.js` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6849e6d5a5e8832e852f6acfa8c2e565